### PR TITLE
prefer pkg-config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,10 @@ script:
 
 jobs:
   include:
-    - env: CIP_TAG=5.29 CIP_ENV=ALIEN_INSTALL_TYPE=share
-    - env: CIP_TAG=5.29 CIP_ENV=ALIEN_INSTALL_TYPE=system
+    - env: CIP_TAG=5.31 CIP_ENV=ALIEN_INSTALL_TYPE=share
+    - env: CIP_TAG=5.31 CIP_ENV=ALIEN_INSTALL_TYPE=system
+    - env: CIP_TAG=5.30 CIP_ENV=ALIEN_INSTALL_TYPE=share
+    - env: CIP_TAG=5.30 CIP_ENV=ALIEN_INSTALL_TYPE=system
     - env: CIP_TAG=5.28 CIP_ENV=ALIEN_INSTALL_TYPE=share
     - env: CIP_TAG=5.28 CIP_ENV=ALIEN_INSTALL_TYPE=system
     - env: CIP_TAG=5.26 CIP_ENV=ALIEN_INSTALL_TYPE=share

--- a/alienfile
+++ b/alienfile
@@ -28,13 +28,13 @@ my @try_flags = (
   { cflags => '-I/usr/local/include/libxml2', libs => '-lxml2' },
 );
 
-plugin 'PkgConfig' => 'libxml-2.0';
-
 probe [
   ['xml2-config', '--version' => \'%{.install.my_version}'],
   ['xml2-config', '--cflags'  => \'%{.install.my_cflags}'],
   ['xml2-config', '--libs'    => \'%{.install.my_libs}'],
 ];
+
+plugin 'PkgConfig' => 'libxml-2.0';
 
 plugin 'Probe::CBuilder' => (
   cflags  => $_->{cflags},


### PR DESCRIPTION
This resolves the specific case in #11 where a user has a broken .pc file (in the #11 case the broken lib is provided by the OS vendor :roll_eyes:  :apple:), but there is a good xml2-config provided by a third party package system.  This unfortunately doesn't solve the problem of having broken .pc files.  AB doesn't currently have a mechanism to test at configure time if the flags provided by pkg-config are bad.  However, it seems to make sense to trust xml2-config over pkg-config in general.  The former being specific to libxml2 and the latter being a general lib flag finder.